### PR TITLE
Add textile bucket publish Github action

### DIFF
--- a/.github/workflows/bucket_push.yml
+++ b/.github/workflows/bucket_push.yml
@@ -1,0 +1,27 @@
+name: bucket_push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  bucket_push:
+    runs-on: ubuntu-latest
+    name: Update a Textile bucket
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Bucket push action
+      id: push
+      uses: textileio/github-action-bucket-push@master
+      with:
+        bucket-name: 'blog-janaka-dev'
+        path: 'public/*'
+        token: ${{ secrets.TEXTILE_AUTH_TOKEN }}
+    - name: Get the output CID
+      run: echo "The CID was ${{ steps.push.outputs.cid }}"
+    - name: Get the Bucket URL
+      run: echo "The Bucket URL is ${{ steps.push.outputs.url }}"


### PR DESCRIPTION
This PR adding a GH action to publish this Gatsby blog to a textile.io bucket on IPFS.